### PR TITLE
⚗️ [PWA] Try to fix the 404 redirect

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -31,8 +31,8 @@ export default defineConfig({
       workbox: {
         // Not sure how this differs from `includeAssets`...
         // globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
-        // Not sure if we actually want to specify this fallback.
-        navigateFallback: '/404',
+        // Using this seems to always `404` for saved "web apps".
+        // navigateFallback: '/404',
       },
 
       // Specify which public assets (in addition to the default html/css/js)


### PR DESCRIPTION
Whenever I open the saved app on my iPhone... it goes to the `404` page. I believe this one setting is the culprit.

It is possible that this may not be needed... and instead, we just need to delete and re-add the app to the Home Screen.