### PR TITLE
✨ [Navigation] Improve current highlight

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -3,6 +3,10 @@ interface ItemDescriptor {
   id: string;
   name: string;
   description: string;
+  // Not using a `current` prop as we need to calculate the
+  // current item via a `script` instead of `frontmatter`.
+  // current?: boolean;
+  // class:list={['Link', {current: item.current}]}
 }
 
 interface Props {
@@ -166,61 +170,18 @@ const {id, items = []} = Astro.props;
   }
 
   /* --- Active Item iteration --- */
-  /* TODO: Replace these with an `active` class instead. */
 
-  html[data-current-index='0'] .Item:nth-child(1) .Link,
-  html[data-current-index='1'] .Item:nth-child(2) .Link,
-  html[data-current-index='2'] .Item:nth-child(3) .Link,
-  html[data-current-index='3'] .Item:nth-child(4) .Link,
-  html[data-current-index='4'] .Item:nth-child(5) .Link,
-  html[data-current-index='5'] .Item:nth-child(6) .Link,
-  html[data-current-index='6'] .Item:nth-child(7) .Link,
-  html[data-current-index='7'] .Item:nth-child(8) .Link,
-  html[data-current-index='8'] .Item:nth-child(9) .Link,
-  html[data-current-index='9'] .Item:nth-child(10) .Link,
-  html[data-current-index='10'] .Item:nth-child(11) .Link,
-  html[data-current-index='11'] .Item:nth-child(12) .Link,
-  html[data-current-index='12'] .Item:nth-child(13) .Link,
-  html[data-current-index='13'] .Item:nth-child(14) .Link,
-  html[data-current-index='14'] .Item:nth-child(15) .Link {
+  .Item[data-current] .Link {
     cursor: url('../assets/svg/cursors/CursorHorns.svg'), not-allowed;
     color: var(--color-primary);
     translate: calc(var(--nav-item-shift-x) * -1) 0;
-  }
 
-  html[data-current-index='0'] .Item:nth-child(1) .Link:active,
-  html[data-current-index='1'] .Item:nth-child(2) .Link:active,
-  html[data-current-index='2'] .Item:nth-child(3) .Link:active,
-  html[data-current-index='3'] .Item:nth-child(4) .Link:active,
-  html[data-current-index='4'] .Item:nth-child(5) .Link:active,
-  html[data-current-index='5'] .Item:nth-child(6) .Link:active,
-  html[data-current-index='6'] .Item:nth-child(7) .Link:active,
-  html[data-current-index='7'] .Item:nth-child(8) .Link:active,
-  html[data-current-index='8'] .Item:nth-child(9) .Link:active,
-  html[data-current-index='9'] .Item:nth-child(10) .Link:active,
-  html[data-current-index='10'] .Item:nth-child(11) .Link:active,
-  html[data-current-index='11'] .Item:nth-child(12) .Link:active,
-  html[data-current-index='12'] .Item:nth-child(13) .Link:active,
-  html[data-current-index='13'] .Item:nth-child(14) .Link:active,
-  html[data-current-index='14'] .Item:nth-child(15) .Link:active {
-    cursor: url('../assets/svg/cursors/CursorHornsClicked.svg'), not-allowed;
-  }
+    &:active {
+      cursor: url('../assets/svg/cursors/CursorHornsClicked.svg'), not-allowed;
+    }
 
-  html[data-current-index='0'] .Item:nth-child(1) .Link::before,
-  html[data-current-index='1'] .Item:nth-child(2) .Link::before,
-  html[data-current-index='2'] .Item:nth-child(3) .Link::before,
-  html[data-current-index='3'] .Item:nth-child(4) .Link::before,
-  html[data-current-index='4'] .Item:nth-child(5) .Link::before,
-  html[data-current-index='5'] .Item:nth-child(6) .Link::before,
-  html[data-current-index='6'] .Item:nth-child(7) .Link::before,
-  html[data-current-index='7'] .Item:nth-child(8) .Link::before,
-  html[data-current-index='8'] .Item:nth-child(9) .Link::before,
-  html[data-current-index='9'] .Item:nth-child(10) .Link::before,
-  html[data-current-index='10'] .Item:nth-child(11) .Link::before,
-  html[data-current-index='11'] .Item:nth-child(12) .Link::before,
-  html[data-current-index='12'] .Item:nth-child(13) .Link::before,
-  html[data-current-index='13'] .Item:nth-child(14) .Link::before,
-  html[data-current-index='14'] .Item:nth-child(15) .Link::before {
-    opacity: 0;
+    &::before {
+      opacity: 0;
+    }
   }
 </style>

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -27,7 +27,7 @@ const OG_IMAGE = new URL('/dulmage-social.png', Astro.site).href;
 ---
 
 <!doctype html>
-<html lang="en" data-current-index="0" data-ready="loading">
+<html lang="en" data-ready="loading">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,16 +43,21 @@ const [intro, ...portfolioSections] = sections;
 <script>
   import {NAV_ID, NAV_TOGGLE_ID, OVERLAY_ID, PERSONAL_EMAIL} from '@data/app';
 
+  import {NavTracker} from '@scripts/NavTracker';
   import {Overlay} from '@scripts/Overlay';
   import {Portfolio} from '@scripts/Portfolio';
   import {SecretEmail} from '@scripts/SecretEmail';
   import {Toggler} from '@scripts/Toggler';
 
+  const navTrackerInstance = new NavTracker(`#${NAV_ID} li`);
+  navTrackerInstance.update();
+
   const overlayInstance = new Overlay(OVERLAY_ID);
   overlayInstance.init();
 
-  // Only pass `{scroller: 'main'}` if we want scroll-snapping.
-  const portfolioInstance = new Portfolio();
+  const portfolioInstance = new Portfolio({}, ({mostVisibleIndex}) => {
+    navTrackerInstance.safeUpdate(mostVisibleIndex);
+  });
   portfolioInstance.init();
 
   const emailInstance = new SecretEmail(PERSONAL_EMAIL);

--- a/src/scripts/NavTracker.ts
+++ b/src/scripts/NavTracker.ts
@@ -1,0 +1,25 @@
+export class NavTracker {
+  #items: NodeListOf<Element>;
+  #lastSavedIndex = 0;
+
+  constructor(selector = 'nav ul li') {
+    this.#items = document.querySelectorAll(selector);
+  }
+
+  update(currentIndex = 0) {
+    this.#items.forEach((element, index) => {
+      if (index === currentIndex) {
+        element.setAttribute('data-current', 'true');
+      } else {
+        element.removeAttribute('data-current');
+      }
+    });
+  }
+
+  safeUpdate(currentIndex = 0) {
+    if (this.#lastSavedIndex === currentIndex) return;
+
+    this.#lastSavedIndex = currentIndex;
+    this.update(currentIndex);
+  }
+}

--- a/src/scripts/PageLoad.ts
+++ b/src/scripts/PageLoad.ts
@@ -26,7 +26,11 @@ export class PageLoad {
   }
 
   static #handleReadyState() {
+    // Before running the timer to "update document", we want to make sure any
+    // hash URL is removed and we reset our scroll position.
+    history.replaceState(null, '', ' ');
     window.scrollTo(0, 0);
+
     window.setTimeout(PageLoad.#updateDocument, PageLoad.MOTION_DELAY);
   }
 


### PR DESCRIPTION
I've authored a custom `NavTracker` so that we do not wait until the current section to be fully switched over before highlighting the corresponding nav item.

I've also removed the `#` from the URL on pageload... in hopes to further improve some of the bad FF Mobile behaviour.