### PR TITLE
⏪ [Navigation] Fix exit animation

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -90,8 +90,12 @@ const {id, items = []} = Astro.props;
     z-index: calc(var(--index-thermosphere) + 1);
     bottom: var(--nav-list-bottom);
     right: 0;
+
+    /*
+    Using this layout breaks the close animation:
     display: grid;
     justify-items: end;
+    */
 
     &[aria-hidden='false'] {
       width: auto;
@@ -103,6 +107,10 @@ const {id, items = []} = Astro.props;
   }
 
   .Item {
+    /* Required for the close animation to work */
+    float: right;
+    clear: both;
+
     transition: translate var(--speed) var(--ease);
     /* Stagger animation offset */
     transition-delay: calc(var(--speed-fastest) * var(--nav-item-index));


### PR DESCRIPTION
> **Reverts:** https://github.com/beefchimi/dulmage/pull/65/commits/c205d8a72e228cdf11f0a46be6d5d30c35cd29fb

I knew there must have been a good reason I was using `float`...